### PR TITLE
Support pre-instantiation dependency loading, add missing try-with-resources

### DIFF
--- a/common-lib/src/main/java/me/bristermitten/pdmlibs/repository/MavenRepository.java
+++ b/common-lib/src/main/java/me/bristermitten/pdmlibs/repository/MavenRepository.java
@@ -57,7 +57,6 @@ public class MavenRepository implements Repository
         {
             containingArtifacts.add(artifact);
         }
-
         return contains;
     }
 

--- a/common-lib/src/main/java/me/bristermitten/pdmlibs/util/Reflection.java
+++ b/common-lib/src/main/java/me/bristermitten/pdmlibs/util/Reflection.java
@@ -1,0 +1,34 @@
+package me.bristermitten.pdmlibs.util;
+
+import java.lang.reflect.Field;
+
+/**
+ * @author Johnny_JayJay (https://www.github.com/JohnnyJayJay)
+ */
+public final class Reflection
+{
+
+    private Reflection()
+    {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T getFieldValue(Object instance, String name)
+    {
+        try
+        {
+            Field field = instance.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            return (T) field.get(instance);
+        }
+        catch (NoSuchFieldException e)
+        {
+            throw new RuntimeException("Field could not be found", e);
+        }
+        catch (IllegalAccessException e)
+        {
+            throw new AssertionError("Field could not be accessed after setting accessible = true", e);
+        }
+    }
+
+}

--- a/common-lib/src/main/java/me/bristermitten/pdmlibs/util/Streams.java
+++ b/common-lib/src/main/java/me/bristermitten/pdmlibs/util/Streams.java
@@ -29,10 +29,11 @@ public final class Streams
     @NotNull
     public static byte[] toByteArray(@NotNull final InputStream stream)
     {
-        try (final ByteArrayOutputStream output = new ByteArrayOutputStream())
+        try (InputStream in = stream)
         {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
             int next;
-            while ((next = stream.read()) != -1)
+            while ((next = in.read()) != -1)
             {
                 output.write(next);
             }

--- a/pdm/src/main/java/me/bristermitten/pdm/PDMBuilder.java
+++ b/pdm/src/main/java/me/bristermitten/pdm/PDMBuilder.java
@@ -1,14 +1,13 @@
 package me.bristermitten.pdm;
 
+import me.bristermitten.pdmlibs.util.Reflection;
 import org.apache.commons.lang.Validate;
-import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.InputStream;
-import java.lang.reflect.Field;
 import java.net.URLClassLoader;
 import java.util.Objects;
 import java.util.function.Function;
@@ -43,31 +42,12 @@ public final class PDMBuilder
         Validate.isTrue("org.bukkit.plugin.java.PluginClassLoader".equals(plugin.getClassLoader().getClass().getName()),
             "Plugin must be loaded with a PluginClassLoader");
         classLoader((URLClassLoader) plugin.getClassLoader());
-        PluginDescriptionFile description = get(classLoader, "description");
+        PluginDescriptionFile description = Reflection.getFieldValue(classLoader, "description");
         dependenciesResource(classLoader.getResourceAsStream(DEPENDENCIES_RESOURCE_NAME));
         rootDirectory(new File("./plugins"));
         applicationName(description.getName());
         applicationVersion(description.getVersion());
         loggerFactory(clazz -> Logger.getLogger(description.getName()));
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> T get(Object instance, String fieldName)
-    {
-        try
-        {
-            Field field = instance.getClass().getDeclaredField(fieldName);
-            field.setAccessible(true);
-            return (T) field.get(instance);
-        }
-        catch (NoSuchFieldException e)
-        {
-            throw new RuntimeException("Field could not be found", e);
-        }
-        catch (IllegalAccessException e)
-        {
-            throw new AssertionError("Field could not be accessed after setting accessible = true", e);
-        }
     }
 
     public PDMBuilder()


### PR DESCRIPTION
This PR introduces a new `PDMBuilder` constructor that only takes a plugin `Class` object and initiates PDM based on its class loader.

This can be useful in situations where you want to load your dependencies before an instance of the plugin is created, e.g. in a static initialiser. This enables you to use dependencies very early, like in static fields or other static initialisers.

Additionally, I improved some code involving unclosed `InputStream`s, using try-with-resources where applicable. I did not scan the entire project for this, so there may be more sections prone to resource leaks.

I decided against deprecating the API that takes `InputStream`s for the `dependencies.json`. I am not familiar enough with this project yet to decide what's best in that regard and what other parts of the code to adjust. I leave this to you or a future PR for now.