### PR TITLE
Set the root directory as the server root folder (where contains worlds, server.properties and so on)

### DIFF
--- a/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/PDMExtension.kt
+++ b/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/PDMExtension.kt
@@ -14,9 +14,10 @@ open class PDMExtension
 		protected set
 
 	/**
-	 * The directory name that dependencies should be downloaded to. If null, PDM resolves this as `PluginLibraries`.
+	 * The directory name that dependencies should be downloaded to. If null, PDM resolves this as `plugins/PluginLibraries`.
 	 * Typically this option should be left alone, to create a shared directory for all plugins to use, but it can be changed if necessary.
 	 *
+	 * Base folder is the server root folder (where contains worlds, server.properties and so on).
 	 */
 	var outputDirectory: String? = null
 		protected set

--- a/pdm/src/main/java/me/bristermitten/pdm/DependencyManager.java
+++ b/pdm/src/main/java/me/bristermitten/pdm/DependencyManager.java
@@ -33,7 +33,7 @@ import static java.util.stream.Collectors.toList;
 public class DependencyManager
 {
 
-    public static final String PDM_DIRECTORY_NAME = "PluginLibraries";
+    public static final String PDM_DIRECTORY_NAME = "plugins/PluginLibraries";
 
     @NotNull
     private final PDMSettings settings;

--- a/pdm/src/main/java/me/bristermitten/pdm/PDMBuilder.java
+++ b/pdm/src/main/java/me/bristermitten/pdm/PDMBuilder.java
@@ -47,7 +47,7 @@ public final class PDMBuilder
         classLoader((URLClassLoader) plugin.getClassLoader());
         PluginDescriptionFile description = Reflection.getFieldValue(classLoader, "description");
         dependenciesResource(classLoader.getResourceAsStream(DEPENDENCIES_RESOURCE_NAME));
-        rootDirectory(new File("./plugins"));
+        rootDirectory(new File("./"));
         applicationName(description.getName());
         applicationVersion(description.getVersion());
         loggerFactory(clazz -> Logger.getLogger(description.getName()));


### PR DESCRIPTION
I think this could be better for when configuring at the Gradle PDM extension `outputDirectory`.

In case you want to have a custom folder that is hidden (by using `.` in Unix based systems).