### PR TITLE
Better support to project type dependencies

### DIFF
--- a/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/PDMExtension.kt
+++ b/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/PDMExtension.kt
@@ -107,4 +107,11 @@ open class PDMExtension
 		config(builder)
 		this.caching = builder.build()
 	}
+
+	/**
+	 * If you are using a module with the all the dependencies that your project uses inside of it to be downloaded by the PDM.
+	 * You can provide your project maven repository URL that will be usage to resolve the Project dependencies,
+	 * example: `pdm(project(":yourmodule"))`.
+	 */
+	var projectRepository: String? = null
 }

--- a/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/PDMGenDependenciesTask.kt
+++ b/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/PDMGenDependenciesTask.kt
@@ -28,6 +28,7 @@ class PDMGenDependenciesTask(
 {
 	companion object
 	{
+		const val PROJECT_REPOSITORY_ALIAS = "project"
 		private val LOGGER = LoggerFactory.getLogger(PDMGenDependenciesTask::class.java)
 	}
 
@@ -48,7 +49,11 @@ class PDMGenDependenciesTask(
 				.map {
 					val url = REPOSITORY_URL_MAPPINGS[it.name]?.invoke(config) ?: it.url.toString()
 					it.name to repositoryFactory.create(url)
-				}.toMap()
+				}.toMap().toMutableMap()
+
+		val projectRepository = config.projectRepository
+		if(projectRepository != null)
+			repositories[PROJECT_REPOSITORY_ALIAS] = repositoryFactory.create(projectRepository)
 
 		val dependencies = pdmDependency.allDependencies.mapNotNull {
 			val group = it.group ?: return@mapNotNull null
@@ -107,7 +112,7 @@ class PDMGenDependenciesTask(
 	{
 		if(isProject && config.projectRepository != null)
 		{
-			return PDMDependency(groupId, artifactId, version, config.projectRepository, null)
+			return PDMDependency(groupId, artifactId, version, PROJECT_REPOSITORY_ALIAS, null)
 		}
 
 		if (spigot && isSpigotArtifact() || !searchRepositories)

--- a/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/json/ArtifactDTO.kt
+++ b/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/json/ArtifactDTO.kt
@@ -3,5 +3,6 @@ package me.bristermitten.pdm.json
 data class ArtifactDTO(
         val group: String,
         val artifact: String,
-        val version: String
+        val version: String,
+        val isProject: Boolean
 )


### PR DESCRIPTION
Use case:
Project module that have all dependencies, and a relocation logic with Shadow plugin, this module will be published with the all dependencies relocated to the project repository.

Currently behavior:
![image](https://user-images.githubusercontent.com/29736164/91730799-9a92b780-eb7c-11ea-9807-0b5021772ea9.png)

What's the PR adds/changes:
Add a new property to the PDM Gradle Extension to be able to set the `projectRepository` that will be usage in `project()` dependencies.
