### PR TITLE
Resolving PDM declaration in submodules

### DIFF
--- a/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/PDM.kt
+++ b/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/PDM.kt
@@ -9,6 +9,9 @@ import java.util.logging.Logger
 
 class PDM : Plugin<Project>
 {
+	companion object {
+		const val CONFIGURATION_NAME = "pdm"
+	}
 	private val artifactFactory = ArtifactFactory()
 
 	private val repositoryManager = RepositoryManager(Logger.getLogger(javaClass.name))
@@ -17,7 +20,7 @@ class PDM : Plugin<Project>
 	{
 		plugins.apply("java") //add the Java Plugin if it's not already present
 
-		val pdmConfig = configurations.create("pdm")
+		val pdmConfig = configurations.create(CONFIGURATION_NAME)
 		val compileConfig = configurations.findByName("compileOnly")
 		requireNotNull(compileConfig) {
 			"No 'compileOnly' configuration defined. Is the Java plugin present?"

--- a/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/ProjectState.kt
+++ b/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/ProjectState.kt
@@ -7,3 +7,8 @@ data class ProjectState(
         val repos: Map<String, Repository>,
         val dependencies: Set<ArtifactDTO>
 )
+
+operator fun ProjectState.plus(projectState: ProjectState): ProjectState
+{
+    return ProjectState(repos + projectState.repos, dependencies + projectState.dependencies)
+}


### PR DESCRIPTION
This pull request makes the gradle plugin resolve pdm declaration for submodules with configurations that extends from `compile`.

Example:

Main Module
```kotlin
dependencies {
   pdm(kotlin("stdlib-jdk8"))
   project(":configuration")
}
```

Configuration module
```kotlin
dependencies {
  pdm("org.yaml:snakeyaml:1.26")
  pdm(kotlin("reflect"))
}
```

When the main module get compiled, will have all the pdm's dependencies including from the module `configuration`.
