### PR TITLE
Supporting gradle exclude rules for transitive dependencies in PDM

### DIFF
--- a/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/PDM.kt
+++ b/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/PDM.kt
@@ -62,5 +62,12 @@ class PDM : Plugin<Project>
 		project.task("pdmGenDependencies").doLast {
 			dependenciesTask.invoke(project)
 		}
+
+		project.task("pdmInvalidateCache").doLast {
+			val cache = project.buildDir.resolve("tmp").resolve("pdm").resolve("cache")
+
+			if(cache.exists())
+				cache.deleteRecursively()
+		}
 	}
 }

--- a/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/json/ArtifactDTO.kt
+++ b/pdm-gradle/src/main/kotlin/me/bristermitten/pdm/json/ArtifactDTO.kt
@@ -1,8 +1,25 @@
 package me.bristermitten.pdm.json
 
+import me.bristermitten.pdmlibs.artifact.Artifact
+
 data class ArtifactDTO(
         val group: String,
         val artifact: String,
         val version: String,
-        val isProject: Boolean
+        val isProject: Boolean,
+        val exclusions: List<ExcludeRule>
 )
+
+data class ExcludeRule(val group: String?, val module: String?)
+{
+    fun match(artifact: Artifact): Boolean
+    {
+        return if(group != null && module != null) {
+            artifact.groupId.equals(group, ignoreCase = true) && artifact.artifactId.equals(module, ignoreCase = true)
+        } else if(group != null) {
+            artifact.groupId.equals(group, ignoreCase = true)
+        } else {
+            artifact.artifactId.equals(module, ignoreCase = true)
+        }
+    }
+}


### PR DESCRIPTION
Adding support to exclusion of transitive dependencies in the gradle pdm declaration. (Related: #6)

```kotlin
dependencies {
   pdm("org.jetbrains.exposed:exposed-core:0.24.1") {
       exclude(module = "kotlin-stdlib")
   }
}
```
Currently behavior is that the exclusion is ignored and not processed by PDM, meaning that even if you exclude in gradle, PDM will continue to resolve all transitive dependencies including `ktolin-stdlib`. With this pull request, depedency exclusion works.

Extra:
Currently, PDM does not cache the transitive dependencies, this means that the cache with transitive dependencies or without on your `dependencies.json` will be the same and it will be continue using the previous `dependencies.json` already processed. Address this problem, the PR also adds a new task called `pdmInvalidateCache` that will invalidate the cache making your transitive dependencies be processed again.