### PR TITLE
Minor cleanup of spigot/api subproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ run/
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+
+# Ignore gradle configuration directory
+.gradle/

--- a/pdm/src/main/java/me/bristermitten/pdm/DependencyLoader.java
+++ b/pdm/src/main/java/me/bristermitten/pdm/DependencyLoader.java
@@ -36,6 +36,7 @@ public class DependencyLoader
         {
             return;
         }
+
         if (loaded.contains(file))
         {
             return;
@@ -46,9 +47,9 @@ public class DependencyLoader
             ClassLoaderReflection.addURL(classLoader, file.toURI().toURL());
             loaded.add(file);
         }
-        catch (MalformedURLException e)
+        catch (MalformedURLException exception)
         {
-            logger.log(Level.SEVERE, e, () -> "Could not load dependency from file " + file);
+            logger.log(Level.SEVERE, exception, () -> "Could not load dependency from file " + file);
         }
     }
 }

--- a/pdm/src/main/java/me/bristermitten/pdm/PDMSettings.java
+++ b/pdm/src/main/java/me/bristermitten/pdm/PDMSettings.java
@@ -1,5 +1,7 @@
 package me.bristermitten.pdm;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.File;
 import java.net.URLClassLoader;
 import java.util.function.Function;
@@ -12,23 +14,27 @@ public class PDMSettings
     private final Function<String, Logger> loggerSupplier;
     private final URLClassLoader classLoader;
 
-    public PDMSettings(File rootDirectory, Function<String, Logger> loggerSupplier, URLClassLoader classLoader)
+    public PDMSettings(@NotNull final File rootDirectory, @NotNull final Function<String, Logger> loggerSupplier,
+                       @NotNull final URLClassLoader classLoader)
     {
         this.rootDirectory = rootDirectory;
         this.loggerSupplier = loggerSupplier;
         this.classLoader = classLoader;
     }
 
+    @NotNull
     public URLClassLoader getClassLoader()
     {
         return classLoader;
     }
 
+    @NotNull
     public File getRootDirectory()
     {
         return rootDirectory;
     }
 
+    @NotNull
     public Function<String, Logger> getLoggerSupplier()
     {
         return loggerSupplier;

--- a/pdm/src/main/java/me/bristermitten/pdm/dependency/JSONDependencies.java
+++ b/pdm/src/main/java/me/bristermitten/pdm/dependency/JSONDependencies.java
@@ -1,6 +1,7 @@
 package me.bristermitten.pdm.dependency;
 
 import me.bristermitten.pdmlibs.artifact.ArtifactDTO;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
@@ -9,24 +10,29 @@ import java.util.Set;
 public class JSONDependencies
 {
 
+    @NotNull
     private final Map<String, String> repositories;
+    @NotNull
     private final Set<ArtifactDTO> dependencies;
 
     @Nullable
     private final String dependenciesDirectory;
 
-    public JSONDependencies(Map<String, String> repositories, Set<ArtifactDTO> dependencies, @Nullable String dependenciesDirectory)
+    public JSONDependencies(@NotNull final Map<String, String> repositories, @NotNull final Set<ArtifactDTO> dependencies,
+                            @Nullable final String dependenciesDirectory)
     {
         this.repositories = repositories;
         this.dependencies = dependencies;
         this.dependenciesDirectory = dependenciesDirectory;
     }
 
+    @NotNull
     public Map<String, String> getRepositories()
     {
         return repositories;
     }
 
+    @NotNull
     public Set<ArtifactDTO> getDependencies()
     {
         return dependencies;

--- a/pdm/src/main/java/me/bristermitten/pdm/repository/SpigotRepository.java
+++ b/pdm/src/main/java/me/bristermitten/pdm/repository/SpigotRepository.java
@@ -1,11 +1,13 @@
 package me.bristermitten.pdm.repository;
 
+import com.google.common.collect.ImmutableSet;
 import me.bristermitten.pdmlibs.artifact.Artifact;
 import me.bristermitten.pdmlibs.http.HTTPService;
 import me.bristermitten.pdmlibs.pom.ParseProcess;
 import me.bristermitten.pdmlibs.repository.MavenRepository;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.*;
 import java.util.logging.Logger;
@@ -14,61 +16,59 @@ public final class SpigotRepository extends MavenRepository
 {
 
     public static final String SPIGOT_ALIAS = "spigot-repo";
-    private static final Set<String> SPIGOT_DEPENDENCY_GROUPS = Collections.unmodifiableSet(
-            new HashSet<>(
-                    Arrays.asList(
-                            "net.minecraft",
-                            "org.spigotmc",
-                            "org.bukkit",
-                            "com.destroystokyo.paper"
-                    )
-            )
-    );
-    private static final Set<String> SPIGOT_DEPENDENCY_ARTIFACTS = Collections.unmodifiableSet(
-            new HashSet<>(
-                    Arrays.asList(
-                            "server",
-                            "spigot",
-                            "spigot-api",
-                            "bukkit",
-                            "craftbukkit",
-                            "paper-api"
-                    )
-            )
-    );
 
-    @NotNull
-    private final Logger logger = Logger.getLogger("SpigotRepository");
+    @Unmodifiable private static final Set<String> SPIGOT_DEPENDENCY_GROUPS = new ImmutableSet.Builder<String>()
+            .add(
+                    "net.minecraft",
+                    "org.spigotmc",
+                    "org.bukkit",
+                    "com.destroystokyo.paper"
+            ).build();
+    @Unmodifiable private static final Set<String> SPIGOT_DEPENDENCY_ARTIFACTS = new ImmutableSet.Builder<String>()
+            .add(
+                    "server",
+                    "spigot",
+                    "spigot-api",
+                    "bukkit",
+                    "craftbukkit",
+                    "paper-api"
+            ).build();
+    private static final Logger LOGGER = Logger.getLogger("SpigotRepository");
 
-    public SpigotRepository(@NotNull HTTPService httpService, @NotNull ParseProcess<Set<Artifact>> parseProcess)
+    public SpigotRepository(@NotNull final HTTPService httpService, @NotNull final ParseProcess<Set<Artifact>> parseProcess)
     {
         super(SPIGOT_ALIAS, httpService, parseProcess);
     }
 
 
+    @NotNull
     @Override
-    public @NotNull Set<Artifact> getTransitiveDependencies(@NotNull Artifact dependency)
+    public Set<Artifact> getTransitiveDependencies(@NotNull final Artifact dependency)
     {
         return Collections.emptySet();
     }
 
     @Override
-    public boolean contains(@NotNull Artifact artifact)
+    public boolean contains(@NotNull final Artifact artifact)
     {
         return isSpigotDependency(artifact);
     }
 
+    @NotNull
     @Override
-    public byte @NotNull [] download(@NotNull Artifact dependency)
+    public byte @NotNull [] download(@NotNull final Artifact dependency)
     {
-        if (!dependency.getVersion().contains(Bukkit.getVersion()))
+        final String version = Bukkit.getVersion();
+
+        if (!dependency.getVersion().contains(version))
         {
-            logger.warning(() -> "Dependency on " + dependency + " does not match server version of " + Bukkit.getVersion() + ". This could cause version problems.");
+            LOGGER.warning(() -> "Dependency on " + dependency + " does not match server version of " + version + ". This could cause version problems.");
         }
+
         return new byte[0];
     }
 
-    private boolean isSpigotDependency(@NotNull Artifact dependency)
+    private boolean isSpigotDependency(@NotNull final Artifact dependency)
     {
         return SPIGOT_DEPENDENCY_GROUPS.contains(dependency.getGroupId().toLowerCase()) &&
                 SPIGOT_DEPENDENCY_ARTIFACTS.contains(dependency.getArtifactId().toLowerCase());
@@ -82,12 +82,13 @@ public final class SpigotRepository extends MavenRepository
         if (!(o instanceof SpigotRepository)) return false;
         if (!super.equals(o)) return false;
         SpigotRepository that = (SpigotRepository) o;
-        return logger.equals(that.logger);
+        //todo: what the fuck is this?
+        return LOGGER.equals(that.LOGGER);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(super.hashCode(), logger);
+        return Objects.hash(super.hashCode(), LOGGER);
     }
 }

--- a/pdm/src/main/java/me/bristermitten/pdm/util/ClassLoaderReflection.java
+++ b/pdm/src/main/java/me/bristermitten/pdm/util/ClassLoaderReflection.java
@@ -10,38 +10,39 @@ import java.net.URLClassLoader;
 public class ClassLoaderReflection
 {
 
-    private static final Method addUrlMethod;
+    private static final Method ADD_URL_METHOD;
 
     static
     {
-        Method addURL;
+        final Method addURL;
+
         try
         {
             addURL = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
             addURL.setAccessible(true);
         }
-        catch (NoSuchMethodException e)
+        catch (NoSuchMethodException exception)
         {
-            addURL = null;
-            e.printStackTrace();
+            throw new AssertionError(exception);
         }
-        addUrlMethod = addURL;
+
+        ADD_URL_METHOD = addURL;
     }
 
     private ClassLoaderReflection()
     {
-
+        throw new AssertionError("This class cannot be instantiated.");
     }
 
-    public static void addURL(URLClassLoader classLoader, URL url)
+    public static void addURL(@NotNull final URLClassLoader classLoader, @NotNull final URL url)
     {
         try
         {
-            addUrlMethod.invoke(classLoader, url);
+            ADD_URL_METHOD.invoke(classLoader, url);
         }
-        catch (@NotNull IllegalAccessException | InvocationTargetException e)
+        catch (IllegalAccessException | InvocationTargetException exception)
         {
-            throw new IllegalArgumentException(e);
+            throw new IllegalArgumentException(exception);
         }
     }
 }

--- a/pdm/src/main/java/me/bristermitten/pdm/util/Constants.java
+++ b/pdm/src/main/java/me/bristermitten/pdm/util/Constants.java
@@ -5,8 +5,10 @@ import com.google.gson.Gson;
 public class Constants
 {
 
-    private Constants() {
-
+    private Constants()
+    {
+        throw new AssertionError("This class cannot be instantiated.");
     }
+
     public static final Gson GSON = new Gson();
 }

--- a/pdm/src/main/java/me/bristermitten/pdm/util/FileUtils.java
+++ b/pdm/src/main/java/me/bristermitten/pdm/util/FileUtils.java
@@ -9,11 +9,12 @@ import java.io.InputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 
-public final class FileUtil
+public final class FileUtils
 {
 
-    private FileUtil()
+    private FileUtils()
     {
+        throw new AssertionError("This class cannot be instantiated.");
     }
 
     /**


### PR DESCRIPTION
Not really sure if it's the spigot, or api, or whatever subproject, but essentially just the one called `pdm`. Main changes are some api changes, and an attempt to make the code a little more consistent, style wise.

API Changes:
- Converted PDMBuilder initialization methods from constructors, to static factories. The constructors have been deprecated, and if you don't care about compatibility, these constructors should be outright removed (except the no-arg, which should instead be made private)
- Renamed FileUtil to FileUtils. There is multiple utility functions in this class, `Utils` seemed like a better fit.

As a side note, I'm personally not a fan of constants classes, like the one you've got in here which stores a gson instance. The only benefit I can think of is preserving memory, but for that reason alone, this is a micro optimization at best. On the other hand, having designated gson instances per class, where they're needed, is cleaner imo.